### PR TITLE
3 endpoint create subscription

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem "rack-cors"
 
+# Use jsonapi-serializer for JSON API serialization
+gem "jsonapi-serializer"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     io-console (0.6.0)
     irb (1.7.4)
       reline (>= 0.3.6)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -192,6 +194,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  jsonapi-serializer
   pg (~> 1.1)
   pry
   puma (~> 5.0)

--- a/app/controllers/api/v0/customer_tea_subscriptions_controller.rb
+++ b/app/controllers/api/v0/customer_tea_subscriptions_controller.rb
@@ -1,0 +1,18 @@
+class Api::V0::CustomerTeaSubscriptionsController < ApplicationController
+  rescue_from ActiveRecord::RecordInvalid, with: :render_record_invalid
+
+  def create
+    @sub = CustomerTeaSubscription.create!(customer_tea_subscription_params)
+    render json: CustomerTeaSubscriptionSerializer.new(@sub), status: 201
+  end
+
+  private
+
+  def customer_tea_subscription_params
+    params.permit(:customer_id, :tea_id, :subscription_id)
+  end
+
+  def render_record_invalid(exception)
+    render json: ErrorSerializer.serialize(exception, 404), status: 404
+  end
+end

--- a/app/serializers/customer_tea_subscription_serializer.rb
+++ b/app/serializers/customer_tea_subscription_serializer.rb
@@ -1,0 +1,9 @@
+class CustomerTeaSubscriptionSerializer
+  include JSONAPI::Serializer
+
+  attributes :id,
+             :customer_id,
+             :tea_id,
+             :subscription_id,
+             :status
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,15 @@
+class ErrorSerializer
+  include JSONAPI::Serializer
+
+  def self.serialize(errors, status)
+    {
+      errors: [
+        {
+          status: status.to_s,
+          title: "Record invalid",
+          detail: errors.message
+        }
+      ]
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,10 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+
+  namespace :api do
+    namespace :v0 do
+      post '/subscriptions', to: 'customer_tea_subscriptions#create'
+    end
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,10 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+CustomerTeaSubscription.destroy_all
+Customer.destroy_all
+Tea.destroy_all
+Subscription.destroy_all
 
 # Teas
 # Source: https://www.stashtea.com/
@@ -18,11 +22,12 @@ sub_6 = Subscription.create!(title: 'Six Month Subscription', price: 15, plan_le
 sub_12 = Subscription.create!(title: 'Twelve Month Subscription', price: 12, plan_length: 12)
 
 # Customers
-cust_1 = Customer.create!(first_name: 'John', last_name:'Smith', email: 'johnsmith423@email.com', street_address: '123 Main St', city: 'New York', state: 'NY', zip: '10001')
-cust_2 = Customer.create!(first_name: 'Wei', last_name:'Chen', email: 'wchen32@email.com', street_address: '456 Oak Rd', city: 'Los Angeles', state: 'CA', zip: '90001')
-cust_3 = Customer.create!(first_name: 'Alejandro', last_name:'Gomez', email: 'agomez99@email.com', street_address: '789 Elm St', city: 'Chicago', state: 'IL', zip: '60001')
-cust_4 = Customer.create!(first_name: 'Jessica', last_name:'Davis', email: 'jdavis044@email.com', street_address: '135 Pine Ave', city: 'Houston', state: 'TX', zip: '70001')
-cust_5 = Customer.create!(first_name: 'Takashi', last_name:'Sato', email: 'tsato88@email.com', street_address: '246 Cedar Ln', city: 'Phoenix', state: 'AZ', zip: '85001')
+cust_1 = Customer.create!(first_name: 'John', last_name: 'Smith', email: 'johnsmith423@email.com', street_address: '123 Main St', city: 'New York', state: 'NY', zip: '10001')
+cust_2 = Customer.create!(first_name: 'Wei', last_name: 'Chen', email: 'wchen32@email.com', street_address: '456 Oak Rd', city: 'Los Angeles', state: 'CA', zip: '90001')
+cust_3 = Customer.create!(first_name: 'Alejandro', last_name: 'Gomez', email: 'agomez99@email.com', street_address: '789 Elm St', city: 'Chicago', state: 'IL', zip: '60001')
+cust_4 = Customer.create!(first_name: 'Jessica', last_name: 'Davis', email: 'jdavis044@email.com', street_address: '135 Pine Ave', city: 'Houston', state: 'TX', zip: '70001')
+cust_5 = Customer.create!(first_name: 'Takashi', last_name: 'Sato', email: 'tsato88@email.com', street_address: '246 Cedar Ln', city: 'Phoenix', state: 'AZ', zip: '85001')
+cust_6 = Customer.create!(first_name: 'Grace', last_name: 'Joh', email: 'test@email.com', street_address: '12456 Demo Rd', city: 'Dallas', state: 'TX', zip: '75057')
 
 # CustomerTeaSubscriptions
 # Customer 1 has 2 active subscriptions and 1 cancelled
@@ -41,3 +46,4 @@ cust_sub_33 = CustomerTeaSubscription.create!(customer: cust_3, tea: oolong_tea,
 cust_sub_41 = CustomerTeaSubscription.create!(customer: cust_4, tea: assam_tea, subscription: sub_3, status: 1)
 cust_sub_42 = CustomerTeaSubscription.create!(customer: cust_4, tea: oolong_tea, subscription: sub_6, status: 1)
 # Customer 5 has 0 subscriptions
+# Customer 6 for demo

--- a/spec/requests/api/v0/customer_tea_subscriptions/post_request_spec.rb
+++ b/spec/requests/api/v0/customer_tea_subscriptions/post_request_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe "Subscribe a customer to a tea subscription" do
+  before(:each) do
+    @assam_tea = Tea.create!(name: 'Assam Tea', description: 'A medium-bodied, brisk organic black tea with a distinctive malty flavor. A satisfying cup that is good with or without milk and sweetener.', brew_temp_f: 200, brew_time_min: 3, brew_time_max: 5)
+    @sub_3 = Subscription.create!(title: 'Three Month Subscription', price: 16, plan_length: 3)
+    @cust_1 = Customer.create!(first_name: 'John', last_name:'Smith', email: 'johnsmith423@email.com', street_address: '123 Main St', city: 'New York', state: 'NY', zip: '10001')
+  end
+
+  describe "Happy path" do
+    it 'creates a new customer tea subscription' do
+      params = { customer_id: @cust_1.id, tea_id: @assam_tea.id, subscription_id: @sub_3.id }
+      @headers = { 'CONTENT_TYPE' => 'application/json' }
+
+      post '/api/v0/subscriptions', headers: @headers, params: JSON.generate(params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      expect(data).to be_a Hash
+      expect(data).to have_key(:data)
+
+      sub_data = data[:data]
+      expect(sub_data).to be_a Hash
+
+      expect(sub_data).to have_key(:id)
+      expect(sub_data[:id]).to be_a String
+      expect(sub_data).to have_key(:type)
+      expect(sub_data[:type]).to eq('customer_tea_subscription')
+      expect(sub_data).to have_key(:attributes)
+      expect(sub_data[:attributes]).to be_a Hash
+
+      subscr_attr = sub_data[:attributes]
+      expect(subscr_attr).to have_key(:customer_id)
+      expect(subscr_attr[:customer_id]).to be_a Integer
+      expect(subscr_attr).to have_key(:tea_id)
+      expect(subscr_attr[:tea_id]).to be_a Integer
+      expect(subscr_attr).to have_key(:subscription_id)
+      expect(subscr_attr[:subscription_id]).to be_a Integer
+      expect(subscr_attr).to have_key(:status)
+      expect(subscr_attr[:status]).to eq('active')
+    end
+  end
+
+  describe "Sad path" do
+    it 'returns an error if customer_id is invalid' do
+      params = { customer_id: 20, tea_id: @assam_tea.id, subscription_id: @sub_3.id }
+      @headers = { 'CONTENT_TYPE' => 'application/json' }
+
+      post '/api/v0/subscriptions', headers: @headers, params: JSON.generate(params)
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+
+      error_data = JSON.parse(response.body, symbolize_names: true)
+      expect(error_data).to be_a Hash
+      expect(error_data).to have_key(:errors)
+      expect(error_data[:errors]).to be_an Array
+      error = error_data[:errors].first
+      expect(error).to have_key(:status)
+      expect(error[:status]).to eq('404')
+      expect(error).to have_key(:title)
+      expect(error[:title]).to eq('Record invalid')
+      expect(error).to have_key(:detail)
+      expect(error[:detail]).to eq('Validation failed: Customer must exist')
+    end
+  end
+end


### PR DESCRIPTION
## Changes
- This PR closes #3 
- add gem `jsonapi-serializer`
- add demo customer to seeds 
- create request test for endpoint
- create `POST api/v0/subscriptions` route
- create CustomerTeaSubscriptionsController with create action
- create serializers

## Testing Checklist
- [x] Tests created for new features 
- [x] All tests pass - Testing Coverage: 100%

## Notes/Encouragement to Self
- Have you taken a POM in the last 30 minutes? no..
  - but push through!
- Questions/things to note that came up:
  - Check JSON contract for request body ids as integers
  - What if a subscription already exists? (either active or cancelled)
  - Refactor error handling....
